### PR TITLE
Document Watchdog v0.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,12 @@ The v0.2 illustrative acceptance run now connects this result through Watchdog a
 |---|---|
 | FinOps Lite | `0.2.x` |
 | CCAC | `ccac/1.0.0` |
-| FinOps Watchdog | `0.2.x` |
+| FinOps Watchdog | `0.4.x` |
 | Tech Spend Command Center | `0.2.x` |
+
+FinOps Lite remains `0.2.0`, while FinOps Watchdog is independently versioned
+at `0.4.x`. Compatible tools do not need identical application package
+versions; their shared interchange contract remains `ccac/1.0.0`.
 
 ## License
 


### PR DESCRIPTION
## What changed

- update the FinOps Watchdog compatibility entry from `0.2.x` to `0.4.x`
- clarify that FinOps Lite remains `0.2.0` and the shared interchange contract remains `ccac/1.0.0`
- document that compatible producer applications are independently versioned

## Scope

Documentation only. No code, calculation, schema, package, fixture, test, workflow, or generated-output change.

## Verification

- 72 repository-root tests passed
- 72 installed-wheel tests passed from outside the repository
- Black, isort, actionable Flake8, dependency audit, workflow YAML parsing, build, clean installation, CLI version, and `git diff --check` passed
- complete six-wheel pipeline passed twice with byte-identical outputs
