### PR TITLE
Correct FinOps Lite release lineage for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.2.0 — 2026-08-04
+## 0.3.0 — Unreleased
+
+Version 0.3.0 is the first release of the audited canonical CCAC pipeline
+implementation. The existing public `v0.2.0` tag and January 2026 GitHub
+release predate this implementation, and the package at that tag internally
+declared version `0.1.0`. Advancing to `0.3.0` preserves release chronology
+without rewriting historical tags or releases and does not change the already
+approved financial or analytical behavior.
 
 - Add a standard `finops-lite --version` installation smoke check.
 - Add deterministic `finops ccac --demo` and real AWS `finops ccac` output conforming to `ccac/1.0.0`.

--- a/README.md
+++ b/README.md
@@ -133,16 +133,16 @@ billing export or illustrative source
   -> Lumen
 ```
 
-The v0.2 illustrative acceptance run now connects this result through Watchdog and Tech Spend Command Center into a contract-valid trusted report. Cloud Cost Guard remains unchanged until its downstream adapter is reviewed separately.
+The v0.3 illustrative acceptance run connects this result through Watchdog and Tech Spend Command Center into a contract-valid trusted report. Cloud Cost Guard remains unchanged until its downstream adapter is reviewed separately.
 
 | Component | Compatible version |
 |---|---|
-| FinOps Lite | `0.2.x` |
+| FinOps Lite | `0.3.x` |
 | CCAC | `ccac/1.0.0` |
 | FinOps Watchdog | `0.4.x` |
 | Tech Spend Command Center | `0.2.x` |
 
-FinOps Lite remains `0.2.0`, while FinOps Watchdog is independently versioned
+FinOps Lite is `0.3.x`, while FinOps Watchdog is independently versioned
 at `0.4.x`. Compatible tools do not need identical application package
 versions; their shared interchange contract remains `ccac/1.0.0`.
 

--- a/finops_lite/__init__.py
+++ b/finops_lite/__init__.py
@@ -5,7 +5,7 @@ A professional-grade command-line tool that brings AWS cost management
 directly to your terminal.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __author__ = "Diana"
 __email__ = "diana@cloudandcapital.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "finops-lite"
-version = "0.2.0"
+version = "0.3.0"
 description = "AWS cost visibility CLI and canonical CCAC producer"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ class TestCLIBasics:
     def test_version_option(self):
         result = CliRunner().invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert result.output.strip() == "finops-lite, version 0.2.0"
+        assert result.output.strip() == "finops-lite, version 0.3.0"
 
     def test_help_command(self):
         """Test help command."""

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "finops-lite"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Corrects the current package lineage to 0.3.0 while preserving the historical v0.2.0 tag and release. Updates authoritative version surfaces and compatibility documentation only; analytical behavior and ccac/1.0.0 are unchanged.

Verification: 72 root tests; complete six-wheel suite 504 passed; formatting, import order, actionable Flake8, dependency audit, workflow YAML, builds, clean wheel install, installed version, deterministic demos, and complete pipeline validation passed.