### PR TITLE
Emit canonical Cloud scope under CCAC 1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,14 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --locked --extra dev
+      - name: Install verified CCAC 0.2.0 release validator
+        run: |
+          curl --fail --location --silent --show-error --output /tmp/cloudandcapital_ccac-0.2.0-py3-none-any.whl https://github.com/cloudandcapital/cloud-capital-analysis-contract/releases/download/v0.2.0/cloudandcapital_ccac-0.2.0-py3-none-any.whl
+          echo "bc46f363b1a03c94cf0da75759bccd0271de2c53b1f77a1a7255f9c8e7f768f1  /tmp/cloudandcapital_ccac-0.2.0-py3-none-any.whl" | sha256sum --check
+          uv pip install --python .venv/bin/python /tmp/cloudandcapital_ccac-0.2.0-py3-none-any.whl
       - run: uv run pytest tests/ -q
+        env:
+          REQUIRE_CCAC_RELEASE_VALIDATION: "1"
 
   package:
     name: Package smoke test
@@ -76,3 +83,4 @@ jobs:
           package-smoke/bin/finops-lite --no-cache ccac --demo > demo-1.json
           package-smoke/bin/finops-lite --no-cache ccac --demo > demo-2.json
           cmp demo-1.json demo-2.json
+          package-smoke/bin/finops-lite --no-cache ccac --demo --contract-version 1.1.0 > demo-1.1.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0 — Unreleased
+
+- Preserve `ccac/1.0.0` as the default and add explicit 1.0/1.1 contract selection.
+- Emit exactly one canonical Cloud scope metric for `ccac/1.1.0`.
+- Use AWS Cost Explorer `NetUnblendedCost` for real 1.1 output without a blended-cost fallback.
+- Mark real AWS-only Cloud coverage partial and ineligible for an all-in technology-spend total.
+- Validate deterministic illustrative 1.1 output with the released CCAC 0.2.0 wheel.
+
 ## 0.3.0 — Unreleased
 
 Version 0.3.0 is the first release of the audited canonical CCAC pipeline

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ finops --no-cache ccac \
 
 The command retrieves the complete service breakdown rather than truncating it to the top ten. It refuses to emit a canonical result when daily service rows, service totals, daily totals, and the reported total do not reconcile.
 
-The explicit 1.1 path requests AWS Cost Explorer `NetUnblendedCost`, which AWS defines as cost after discounts, and maps it to CCAC `net_cost`. It does not fall back to `BlendedCost`. Because the query has no record-type filter, returned credits, taxes, adjustments, and shared-service rows remain included. The canonical Cloud metric includes provider-billed native AI and excludes direct AI-vendor billing.
+The explicit real 1.1 path requests AWS Cost Explorer `NetUnblendedCost`, which AWS defines as cost after discounts, and maps it to CCAC `net_cost`. It does not fall back to `BlendedCost`, and neither current nor previous request passes a charge-type filter. Under Cloud & Capital's technology-spend boundary policy, credits, taxes, adjustments, and shared services are included when AWS returns them in that unfiltered result. The canonical Cloud metric includes provider-billed native AI and excludes direct AI-vendor billing.
+
+The explicit 1.1 demo instead uses a deterministic illustrative net-cost summary modeled for the public scenario. It declares AWS as the scenario's sole illustrative Cloud source; no account or AWS API is queried.
 
 A connected AWS billing view does not prove complete enterprise Cloud coverage. Real 1.1 output therefore preserves the observed AWS value but declares partial coverage and is not eligible for an all-in technology-spend total. Native Azure and Google Cloud billing ingestion remain later work.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Cloud](https://img.shields.io/badge/cloud-AWS-orange)](https://github.com/cloudandcapital/finops-lite)
-[![Contract](https://img.shields.io/badge/CCAC-1.0-blue)](https://github.com/cloudandcapital)
+[![Contract](https://img.shields.io/badge/CCAC-1.0%20%7C%201.1-blue)](https://github.com/cloudandcapital)
 
 FinOps Lite is an open-source AWS cost visibility CLI and the canonical cloud-cost producer for the Cloud & Capital pipeline.
 
 For the complete six-tool demo and roadmap, see [Tech Spend Command Center](https://github.com/cloudandcapital/tech-spend-command-center).
 
-Its first CCAC release reads AWS Cost Explorer, calculates a complete service-level cost summary, reconciles the service and daily views, and emits a versioned `ccac/1.0.0` tool result for downstream analysis.
+FinOps Lite 0.4.0 preserves its `ccac/1.0.0` producer path and adds an explicit `ccac/1.1.0` Cloud accounting-boundary path validated by the released CCAC 0.2.0 reference package.
 
 ## Current scope
 
@@ -57,12 +57,19 @@ Python 3.10 or newer is required.
 finops --no-cache ccac --demo --output finops-lite-result.json
 ```
 
+The default remains `ccac/1.0.0`. Select either supported contract explicitly:
+
+```bash
+finops --no-cache ccac --demo --contract-version 1.0.0 --output finops-lite-result.json
+finops --no-cache ccac --demo --contract-version 1.1.0 --output finops-lite-result.json
+```
+
 The command writes `finops-lite-result.json`; rerunning with the same path
 replaces that explicitly named local file.
 
 The cross-repository acceptance suite validates this artifact against the shared CCAC reference schemas. The `ccac validate` command is available to contributors who install the separate Cloud & Capital CCAC reference package; it is not required to run this demo.
 
-The demo is explicitly labeled `illustrative`, uses a fixed run ID and timestamp, and is byte-for-byte deterministic. It contains 21 consecutive daily observations and one deliberate final-day spend spike so the default FinOps Watchdog detector can be exercised end to end. It passes through the same FinOps Lite CCAC builder used for real summaries.
+The demo is explicitly labeled `illustrative`, declares AWS as the scenario's sole Cloud billing source, uses a fixed run ID and timestamp, and is byte-for-byte deterministic. Its reconciled Cloud value remains USD 2,194.00. It contains 21 consecutive daily observations and one deliberate final-day spend spike so the default FinOps Watchdog detector can be exercised end to end. It passes through the same FinOps Lite CCAC builder used for real summaries.
 
 **Illustrative sample billing data. No customer accounts, credentials, or production resources are connected.**
 
@@ -85,6 +92,7 @@ Generate a canonical result:
 
 ```bash
 finops --no-cache ccac \
+  --contract-version 1.1.0 \
   --start 2026-07-01 \
   --end 2026-07-31 \
   --output finops-lite-result.json
@@ -93,6 +101,10 @@ finops --no-cache ccac \
 `--end` is inclusive at the CLI boundary. The CCAC document converts it to an exclusive period end and records both semantics.
 
 The command retrieves the complete service breakdown rather than truncating it to the top ten. It refuses to emit a canonical result when daily service rows, service totals, daily totals, and the reported total do not reconcile.
+
+The explicit 1.1 path requests AWS Cost Explorer `NetUnblendedCost`, which AWS defines as cost after discounts, and maps it to CCAC `net_cost`. It does not fall back to `BlendedCost`. Because the query has no record-type filter, returned credits, taxes, adjustments, and shared-service rows remain included. The canonical Cloud metric includes provider-billed native AI and excludes direct AI-vendor billing.
+
+A connected AWS billing view does not prove complete enterprise Cloud coverage. Real 1.1 output therefore preserves the observed AWS value but declares partial coverage and is not eligible for an all-in technology-spend total. Native Azure and Google Cloud billing ingestion remain later work.
 
 ## Other cost commands
 
@@ -142,14 +154,14 @@ The v0.3 illustrative acceptance run connects this result through Watchdog and T
 
 | Component | Compatible version |
 |---|---|
-| FinOps Lite | `0.3.x` |
-| CCAC | `ccac/1.0.0` |
+| FinOps Lite | `0.4.x` |
+| CCAC | `ccac/1.0.0`, `ccac/1.1.0` (CCAC package 0.2.0) |
 | FinOps Watchdog | `0.4.x` |
 | Tech Spend Command Center | `0.2.x` |
 
-FinOps Lite is `0.3.x`, while FinOps Watchdog is independently versioned
+FinOps Lite is `0.4.x`, while FinOps Watchdog is independently versioned
 at `0.4.x`. Compatible tools do not need identical application package
-versions; their shared interchange contract remains `ccac/1.0.0`.
+versions. This PR does not connect Cloud Cost Guard and does not change another producer or consumer.
 
 ## License
 

--- a/finops_lite/__init__.py
+++ b/finops_lite/__init__.py
@@ -5,7 +5,7 @@ A professional-grade command-line tool that brings AWS cost management
 directly to your terminal.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "Diana"
 __email__ = "diana@cloudandcapital.com"
 

--- a/finops_lite/ccac.py
+++ b/finops_lite/ccac.py
@@ -153,6 +153,15 @@ def build_ccac_result(
             raise CCACBuildError(
                 "Real CCAC 1.1 output requires AWS Cost Explorer NetUnblendedCost; no fallback is permitted"
             )
+    if contract_version == "1.1.0" and mode == "illustrative":
+        if summary.get("illustrative_cost_basis") != "net_cost":
+            raise CCACBuildError(
+                "Illustrative CCAC 1.1 output requires illustrative_cost_basis=net_cost"
+            )
+        if summary.get("illustrative_cloud_sources") != ["aws"]:
+            raise CCACBuildError(
+                "Illustrative CCAC 1.1 output requires AWS as the sole illustrative Cloud source"
+            )
     source_window = summary.get("window") or {}
     start = _parse_date(source_window.get("start"), "window.start")
     inclusive_end = _parse_date(source_window.get("end"), "window.end")
@@ -163,6 +172,18 @@ def build_ccac_result(
         "end": (inclusive_end + timedelta(days=1)).isoformat(),
         "timezone": "UTC",
     }
+    day_count = (inclusive_end - start).days + 1
+    expected_comparison_window = {
+        "start": (start - timedelta(days=day_count)).isoformat(),
+        "end": (start - timedelta(days=1)).isoformat(),
+    }
+    if (
+        contract_version == "1.1.0"
+        and summary.get("comparison_window") != expected_comparison_window
+    ):
+        raise CCACBuildError(
+            "CCAC 1.1 requires the immediately preceding equal-length comparison_window"
+        )
 
     total = _decimal(summary.get("total_cost"), "total_cost")
     previous = _decimal(summary.get("previous_total_cost"), "previous_total_cost")
@@ -292,6 +313,11 @@ def build_ccac_result(
     )
     if contract_version == "1.1.0":
         illustrative = mode == "illustrative"
+        component_policy = (
+            "Cloud & Capital technology-spend boundary policy: include each charge type when AWS returns it in the unfiltered Cost Explorer result."
+            if not illustrative
+            else "The illustrative scenario follows Cloud & Capital's technology-spend boundary policy without asserting that an AWS API returned any charge type."
+        )
         canonical_metric["accounting_boundary"] = {
             "relationship": "canonical_scope_spend",
             "scope": "cloud",
@@ -300,7 +326,8 @@ def build_ccac_result(
             "cost_basis": "net_cost",
             "currency_minor_unit": 0.01,
             "inclusion_rules": [
-                "Cloud-provider-billed services, including provider-billed native AI, present in the authoritative AWS Cost Explorer summary."
+                "Cloud-provider-billed services, including provider-billed native AI, present in the authoritative source summary.",
+                component_policy,
             ],
             "exclusion_rules": [
                 "Direct AI-vendor billing and SaaS invoice or entitlement charges outside cloud-provider billing."
@@ -323,12 +350,21 @@ def build_ccac_result(
             "allocation_of_metric_id": None,
             "total_eligible": illustrative,
             "eligibility_reason": (
-                "The illustrative scenario declares AWS as its sole Cloud billing source; the unfiltered reconciled NetUnblendedCost summary covers the full scenario."
+                "The deterministic public scenario declares net_cost and AWS as its sole illustrative Cloud source; no account or AWS API was queried."
                 if illustrative
                 else "The connected AWS billing view is observed and reconciled but does not prove complete enterprise Cloud coverage across other AWS views, Azure, or Google Cloud."
             ),
         }
     metrics.append(canonical_metric)
+    previous_period = period
+    if contract_version == "1.1.0":
+        previous_end = start
+        previous_start = start - timedelta(days=day_count)
+        previous_period = {
+            "start": previous_start.isoformat(),
+            "end": previous_end.isoformat(),
+            "timezone": "UTC",
+        }
     metrics.append(
         _metric(
             metric_id="metric.cloud.previous-total",
@@ -337,7 +373,7 @@ def build_ccac_result(
             currency=currency,
             basis="observed",
             additivity="additive",
-            period=period,
+            period=previous_period,
             dimensions={"scope": "cloud", "comparison": "previous_equal_length_period"},
             evidence_id=evidence_id,
         )
@@ -481,8 +517,16 @@ def build_ccac_result(
                 "lossy_mapping": True,
                 "mapping_notes": (
                     [
-                        "AWS Cost Explorer NetUnblendedCost maps to CCAC net_cost; the request has no record-type filter, so returned credits, taxes, adjustments, and shared-service rows remain included.",
-                        "Service-level AWS Cost Explorer summary; not resource-level FOCUS billing rows.",
+                        (
+                            "Deterministic illustrative net-cost summary modeled for the public scenario; no account or AWS API was queried."
+                            if mode == "illustrative"
+                            else "Actual AWS Cost Explorer NetUnblendedCost maps to CCAC net_cost; no charge-type filter is passed, and credits, taxes, adjustments, and shared services are included when AWS returns them."
+                        ),
+                        (
+                            "Service-level illustrative summary; not an AWS query or resource-level billing export."
+                            if mode == "illustrative"
+                            else "Service-level AWS Cost Explorer summary; not resource-level FOCUS billing rows."
+                        ),
                         (
                             "Illustrative AWS is the sole Cloud billing source for this scenario."
                             if mode == "illustrative"
@@ -506,7 +550,11 @@ def build_ccac_result(
                 "kind": "source_query",
                 "source_ids": [source_id],
                 "description": (
-                    "Complete service-level AWS Cost Explorer NetUnblendedCost summary with no record-type filter and an equal-length previous-period comparison."
+                    (
+                        "Deterministic illustrative net-cost summary modeled for the public scenario; no account or AWS API was queried."
+                        if mode == "illustrative"
+                        else "Actual service-level AWS Cost Explorer NetUnblendedCost query with no charge-type filter and an equal-length previous-period comparison."
+                    )
                     if contract_version == "1.1.0"
                     else "Complete service-level AWS Cost Explorer summary with equal-length previous-period comparison."
                 ),
@@ -519,7 +567,18 @@ def build_ccac_result(
             "finops_lite": {
                 "group_by": "SERVICE",
                 **(
-                    {"aws_cost_metric": "NetUnblendedCost", "aws_filter": None}
+                    (
+                        {
+                            "illustrative_cost_basis": "net_cost",
+                            "illustrative_cloud_sources": ["aws"],
+                            "aws_api_queried": False,
+                        }
+                        if mode == "illustrative"
+                        else {
+                            "aws_cost_metric": "NetUnblendedCost",
+                            "aws_filter": None,
+                        }
+                    )
                     if contract_version == "1.1.0"
                     else {}
                 ),
@@ -570,3 +629,12 @@ def illustrative_summary() -> dict[str, Any]:
             for service, share in (("AmazonEC2", 0.7), ("AmazonS3", 0.3))
         ],
     }
+
+
+def illustrative_summary_1_1() -> dict[str, Any]:
+    """Explicit 1.1 public scenario with declared illustrative lineage."""
+    summary = illustrative_summary()
+    summary["illustrative_cost_basis"] = "net_cost"
+    summary["illustrative_cloud_sources"] = ["aws"]
+    summary["comparison_window"] = {"start": "2026-06-10", "end": "2026-06-30"}
+    return summary

--- a/finops_lite/ccac.py
+++ b/finops_lite/ccac.py
@@ -12,7 +12,7 @@ from typing import Any, Mapping
 
 from . import __version__
 
-CONTRACT_VERSION = "ccac/1.0.0"
+SUPPORTED_CONTRACT_VERSIONS = {"1.0.0", "1.1.0"}
 AWS_COST_EXPLORER_API_VERSION = "2017-10-25"
 MONEY_QUANTUM = Decimal("0.01")
 
@@ -129,18 +129,30 @@ def build_ccac_result(
     source_version: str,
     run_id: str | None = None,
     generated_at: str | datetime | None = None,
+    contract_version: str = "1.0.0",
 ) -> dict[str, Any]:
     """Build a reconciled CCAC tool_result from a complete FinOps Lite summary."""
     if mode not in {"illustrative", "real"}:
         raise CCACBuildError("mode must be 'illustrative' or 'real'")
     if not source_type or not source_version:
         raise CCACBuildError("source_type and source_version are required")
+    if contract_version not in SUPPORTED_CONTRACT_VERSIONS:
+        raise CCACBuildError(f"Unsupported CCAC contract version: {contract_version}")
     if summary.get("group_by") != "SERVICE":
         raise CCACBuildError("CCAC 0.1 requires group_by=SERVICE")
 
     currency = str(summary.get("currency", ""))
     if not re.fullmatch(r"[A-Z]{3}", currency):
         raise CCACBuildError(f"Invalid ISO currency: {currency!r}")
+    if contract_version == "1.1.0" and currency != "USD":
+        raise CCACBuildError(
+            "CCAC 1.1 Cloud scope currently supports USD only because its currency minor unit is explicitly 0.01"
+        )
+    if contract_version == "1.1.0" and mode == "real":
+        if summary.get("aws_cost_metric") != "NetUnblendedCost":
+            raise CCACBuildError(
+                "Real CCAC 1.1 output requires AWS Cost Explorer NetUnblendedCost; no fallback is permitted"
+            )
     source_window = summary.get("window") or {}
     start = _parse_date(source_window.get("start"), "window.start")
     inclusive_end = _parse_date(source_window.get("end"), "window.end")
@@ -262,19 +274,61 @@ def build_ccac_result(
     evidence_id = "evidence.finops-lite.cost-summary"
     metrics: list[dict[str, Any]] = []
 
-    metrics.append(
-        _metric(
-            metric_id="metric.cloud.total",
-            name="Cloud cost",
-            value=total,
-            currency=currency,
-            basis="observed",
-            additivity="additive",
-            period=period,
-            dimensions={"scope": "cloud", "provider": "aws"},
-            evidence_id=evidence_id,
-        )
+    canonical_metric_id = (
+        "metric.tech-spend.scope.cloud"
+        if contract_version == "1.1.0"
+        else "metric.cloud.total"
     )
+    canonical_metric = _metric(
+        metric_id=canonical_metric_id,
+        name="Cloud cost",
+        value=total,
+        currency=currency,
+        basis="observed",
+        additivity="additive",
+        period=period,
+        dimensions={"scope": "cloud", "provider": "aws"},
+        evidence_id=evidence_id,
+    )
+    if contract_version == "1.1.0":
+        illustrative = mode == "illustrative"
+        canonical_metric["accounting_boundary"] = {
+            "relationship": "canonical_scope_spend",
+            "scope": "cloud",
+            "canonical_owner": "finops-lite",
+            "source_channel": "cloud_provider_billing",
+            "cost_basis": "net_cost",
+            "currency_minor_unit": 0.01,
+            "inclusion_rules": [
+                "Cloud-provider-billed services, including provider-billed native AI, present in the authoritative AWS Cost Explorer summary."
+            ],
+            "exclusion_rules": [
+                "Direct AI-vendor billing and SaaS invoice or entitlement charges outside cloud-provider billing."
+            ],
+            "coverage": "complete" if illustrative else "partial",
+            "overlap": {
+                "disposition": "resolved",
+                "treatment": "Provider-billed native AI remains in Cloud; direct AI-vendor and SaaS billing channels are excluded.",
+            },
+            "cross_scope_treatments": {
+                "provider_billed_ai": "included",
+                "direct_ai_vendor": "excluded",
+            },
+            "component_treatments": {
+                "credits": "included",
+                "taxes": "included",
+                "adjustments": "included",
+                "shared_services": "included",
+            },
+            "allocation_of_metric_id": None,
+            "total_eligible": illustrative,
+            "eligibility_reason": (
+                "The illustrative scenario declares AWS as its sole Cloud billing source; the unfiltered reconciled NetUnblendedCost summary covers the full scenario."
+                if illustrative
+                else "The connected AWS billing view is observed and reconciled but does not prove complete enterprise Cloud coverage across other AWS views, Azure, or Google Cloud."
+            ),
+        }
+    metrics.append(canonical_metric)
     metrics.append(
         _metric(
             metric_id="metric.cloud.previous-total",
@@ -300,8 +354,8 @@ def build_ccac_result(
             period=period,
             dimensions={"scope": "cloud"},
             evidence_id=evidence_id,
-            formula="metric.cloud.total - metric.cloud.previous-total",
-            input_metric_ids=["metric.cloud.total", "metric.cloud.previous-total"],
+            formula=f"{canonical_metric_id} - metric.cloud.previous-total",
+            input_metric_ids=[canonical_metric_id, "metric.cloud.previous-total"],
         )
     )
     if previous == 0:
@@ -312,7 +366,7 @@ def build_ccac_result(
     else:
         change_pct = (change / previous) * Decimal("100")
         change_basis = "calculated"
-        change_formula = "(metric.cloud.total - metric.cloud.previous-total) / metric.cloud.previous-total * 100"
+        change_formula = f"({canonical_metric_id} - metric.cloud.previous-total) / metric.cloud.previous-total * 100"
         unknown_reason = None
     metrics.append(
         _metric(
@@ -326,7 +380,7 @@ def build_ccac_result(
             dimensions={"scope": "cloud"},
             evidence_id=evidence_id,
             formula=change_formula,
-            input_metric_ids=["metric.cloud.total", "metric.cloud.previous-total"],
+            input_metric_ids=[canonical_metric_id, "metric.cloud.previous-total"],
             unknown_reason=unknown_reason,
         )
     )
@@ -400,7 +454,7 @@ def build_ccac_result(
         )
 
     return {
-        "contract": CONTRACT_VERSION,
+        "contract": f"ccac/{contract_version}",
         "document_type": "tool_result",
         "producer": {"name": "finops-lite", "version": __version__},
         "run_id": _run_id(run_id),
@@ -425,9 +479,21 @@ def build_ccac_result(
                     else "customer_confidential"
                 ),
                 "lossy_mapping": True,
-                "mapping_notes": [
-                    "Service-level AWS Cost Explorer summary; not resource-level FOCUS billing rows."
-                ],
+                "mapping_notes": (
+                    [
+                        "AWS Cost Explorer NetUnblendedCost maps to CCAC net_cost; the request has no record-type filter, so returned credits, taxes, adjustments, and shared-service rows remain included.",
+                        "Service-level AWS Cost Explorer summary; not resource-level FOCUS billing rows.",
+                        (
+                            "Illustrative AWS is the sole Cloud billing source for this scenario."
+                            if mode == "illustrative"
+                            else "One connected AWS billing view does not establish complete enterprise Cloud coverage."
+                        ),
+                    ]
+                    if contract_version == "1.1.0"
+                    else [
+                        "Service-level AWS Cost Explorer summary; not resource-level FOCUS billing rows."
+                    ]
+                ),
             }
         ],
         "quality": {"status": "valid", "issues": []},
@@ -439,7 +505,11 @@ def build_ccac_result(
                 "id": evidence_id,
                 "kind": "source_query",
                 "source_ids": [source_id],
-                "description": "Complete service-level AWS Cost Explorer summary with equal-length previous-period comparison.",
+                "description": (
+                    "Complete service-level AWS Cost Explorer NetUnblendedCost summary with no record-type filter and an equal-length previous-period comparison."
+                    if contract_version == "1.1.0"
+                    else "Complete service-level AWS Cost Explorer summary with equal-length previous-period comparison."
+                ),
                 "locator": "canonical-json:summary",
                 "observed_at": generated_timestamp,
                 "content_sha256": source_hash,
@@ -448,6 +518,11 @@ def build_ccac_result(
         "extensions": {
             "finops_lite": {
                 "group_by": "SERVICE",
+                **(
+                    {"aws_cost_metric": "NetUnblendedCost", "aws_filter": None}
+                    if contract_version == "1.1.0"
+                    else {}
+                ),
                 "source_window_end_semantics": "inclusive",
                 "contract_period_end_semantics": "exclusive",
                 "service_metric_ids": service_metric_ids,

--- a/finops_lite/cli.py
+++ b/finops_lite/cli.py
@@ -1062,6 +1062,7 @@ def run_summarize(
     performance_tracker: Optional[PerformanceTracker] = None,
     logger=None,
     top_n: Optional[int] = 10,
+    cost_metric: str = "BlendedCost",
 ) -> dict:
     """
     Build a compact cost baseline summary dict for the given window.
@@ -1085,6 +1086,7 @@ def run_summarize(
         "profile": config.aws.profile,
         "region": config.aws.region,
         "top_n": top_n,
+        "cost_metric": cost_metric,
     }
 
     summary = None
@@ -1102,7 +1104,7 @@ def run_summarize(
             end_dt,
             granularity="DAILY",
             group_by=[group_by],
-            metrics=["BlendedCost"],
+            metrics=[cost_metric],
         )
         if performance_tracker:
             performance_tracker.record_api_call()
@@ -1112,7 +1114,7 @@ def run_summarize(
             prev_end_dt,
             granularity="DAILY",
             group_by=[group_by],
-            metrics=["BlendedCost"],
+            metrics=[cost_metric],
         )
         if performance_tracker:
             performance_tracker.record_api_call()
@@ -1124,6 +1126,7 @@ def run_summarize(
             window_start=start_date,
             window_end=end_date,
             top_n=top_n,
+            metric_name=cost_metric,
         )
 
         if cache_manager:
@@ -1212,6 +1215,13 @@ def summarize(ctx, start, end, group_by):
 
 @cli.command("ccac")
 @click.option(
+    "--contract-version",
+    type=click.Choice(["1.0.0", "1.1.0"], case_sensitive=True),
+    default="1.0.0",
+    show_default=True,
+    help="CCAC contract version to emit.",
+)
+@click.option(
     "--demo",
     is_flag=True,
     help="Use deterministic illustrative data without AWS credentials.",
@@ -1242,8 +1252,10 @@ def summarize(ctx, start, end, group_by):
     help="Write JSON to this file instead of stdout.",
 )
 @click.pass_context
-def ccac_output(ctx, demo, start, end, run_id, generated_at, output_file):
-    """Emit the canonical CCAC 1.0 FinOps Lite tool result."""
+def ccac_output(
+    ctx, demo, start, end, contract_version, run_id, generated_at, output_file
+):
+    """Emit a canonical CCAC FinOps Lite tool result."""
     from .ccac import (
         AWS_COST_EXPLORER_API_VERSION,
         CCACBuildError,
@@ -1280,6 +1292,9 @@ def ccac_output(ctx, demo, start, end, run_id, generated_at, output_file):
                 performance_tracker=ctx.obj.performance_tracker,
                 logger=ctx.obj.logger,
                 top_n=None,
+                cost_metric=(
+                    "NetUnblendedCost" if contract_version == "1.1.0" else "BlendedCost"
+                ),
             )
             mode = "real"
             source_type = "aws_cost_explorer_api"
@@ -1292,6 +1307,7 @@ def ccac_output(ctx, demo, start, end, run_id, generated_at, output_file):
             source_version=source_version,
             run_id=run_id,
             generated_at=generated_at,
+            contract_version=contract_version,
         )
         payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
         if output_file:

--- a/finops_lite/cli.py
+++ b/finops_lite/cli.py
@@ -1261,6 +1261,7 @@ def ccac_output(
         CCACBuildError,
         build_ccac_result,
         illustrative_summary,
+        illustrative_summary_1_1,
     )
 
     config = ctx.obj.config
@@ -1276,7 +1277,11 @@ def ccac_output(
 
     try:
         if demo:
-            summary = illustrative_summary()
+            summary = (
+                illustrative_summary_1_1()
+                if contract_version == "1.1.0"
+                else illustrative_summary()
+            )
             mode = "illustrative"
             source_type = "finops_lite_demo_summary"
             source_version = "1.0.0"

--- a/finops_lite/summary.py
+++ b/finops_lite/summary.py
@@ -89,6 +89,33 @@ def _daily_totals(cost_data: Dict[str, Any], metric_name: str) -> Dict[str, Deci
     return totals
 
 
+def _validate_complete_dates(
+    cost_data: Dict[str, Any], *, start: date, end: date, label: str
+) -> None:
+    observed: list[date] = []
+    for index, time_period in enumerate(cost_data.get("ResultsByTime", []) or []):
+        raw_date = (time_period.get("TimePeriod") or {}).get("Start")
+        if not raw_date:
+            raise ValueError(f"Missing {label} ResultsByTime[{index}].TimePeriod.Start")
+        try:
+            observed.append(date.fromisoformat(str(raw_date)))
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid {label} Cost Explorer date: {raw_date!r}"
+            ) from exc
+    if len(observed) != len(set(observed)):
+        raise ValueError(f"Duplicate date in {label} Cost Explorer response")
+    expected = {
+        start + timedelta(days=offset) for offset in range((end - start).days + 1)
+    }
+    missing = sorted(expected - set(observed))
+    unexpected = sorted(set(observed) - expected)
+    if missing or unexpected:
+        raise ValueError(
+            f"Incomplete {label} Cost Explorer dates: missing={missing}, unexpected={unexpected}"
+        )
+
+
 def _group_totals(cost_data: Dict[str, Any], metric_name: str) -> Dict[str, Decimal]:
     totals: Dict[str, Decimal] = {}
     for time_period in cost_data.get("ResultsByTime", []) or []:
@@ -146,6 +173,29 @@ def build_cost_summary(
     if metric_name not in {"BlendedCost", "NetUnblendedCost"}:
         raise ValueError(f"Unsupported AWS Cost Explorer metric: {metric_name}")
     currency = _extract_currency(current_data, metric_name)
+    comparison_window: Dict[str, str] | None = None
+    if metric_name == "NetUnblendedCost":
+        duration = (window_end - window_start).days + 1
+        previous_end = window_start - timedelta(days=1)
+        previous_start = previous_end - timedelta(days=duration - 1)
+        _validate_complete_dates(
+            current_data, start=window_start, end=window_end, label="current-period"
+        )
+        _validate_complete_dates(
+            previous_data,
+            start=previous_start,
+            end=previous_end,
+            label="previous-period",
+        )
+        previous_currency = _extract_currency(previous_data, metric_name)
+        if previous_currency != currency:
+            raise ValueError(
+                f"Current/previous currency mismatch: {currency} != {previous_currency}"
+            )
+        comparison_window = {
+            "start": previous_start.isoformat(),
+            "end": previous_end.isoformat(),
+        }
 
     current_totals = _daily_totals(current_data, metric_name)
     daily_group_totals = _daily_group_totals(current_data, metric_name)
@@ -221,4 +271,5 @@ def build_cost_summary(
     }
     if metric_name != "BlendedCost":
         result["aws_cost_metric"] = metric_name
+        result["comparison_window"] = comparison_window
     return result

--- a/finops_lite/summary.py
+++ b/finops_lite/summary.py
@@ -33,67 +33,80 @@ def _round_pct(value: Decimal) -> float:
     return float(value.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP))
 
 
-def _extract_currency(cost_data: Dict[str, Any]) -> str:
+def _extract_currency(cost_data: Dict[str, Any], metric_name: str) -> str:
+    observed: set[str] = set()
     for time_period in cost_data.get("ResultsByTime", []) or []:
         total = time_period.get("Total", {})
-        blended = total.get("BlendedCost") if total else None
-        if blended and blended.get("Unit"):
-            return blended["Unit"]
+        metric = total.get(metric_name) if total else None
+        if metric and metric.get("Unit"):
+            observed.add(str(metric["Unit"]))
 
         for group in time_period.get("Groups", []) or []:
             metrics = group.get("Metrics") or {}
-            blended = metrics.get("BlendedCost") or {}
-            if blended.get("Unit"):
-                return blended["Unit"]
+            metric = metrics.get(metric_name) or {}
+            if metric.get("Unit"):
+                observed.add(str(metric["Unit"]))
 
+    if metric_name == "NetUnblendedCost":
+        if not observed:
+            raise ValueError("Missing currency for AWS Cost Explorer NetUnblendedCost")
+        if len(observed) != 1:
+            raise ValueError(
+                f"Mixed currency for AWS Cost Explorer NetUnblendedCost: {sorted(observed)}"
+            )
+        return next(iter(observed))
+    if observed:
+        return next(iter(observed))
     return "USD"
 
 
-def _period_total(time_period: Dict[str, Any]) -> Decimal:
+def _period_total(time_period: Dict[str, Any], metric_name: str) -> Decimal:
     total = time_period.get("Total") or {}
-    blended = total.get("BlendedCost") or {}
-    if blended.get("Amount") is not None:
-        return _to_decimal(blended.get("Amount"), field="Total.BlendedCost.Amount")
+    metric = total.get(metric_name) or {}
+    if metric.get("Amount") is not None:
+        return _to_decimal(metric.get("Amount"), field=f"Total.{metric_name}.Amount")
 
     # Fall back to summing group costs.
     total_amount = Decimal("0")
     for group in time_period.get("Groups", []) or []:
         metrics = group.get("Metrics") or {}
-        blended = metrics.get("BlendedCost") or {}
+        metric = metrics.get(metric_name) or {}
         total_amount += _to_decimal(
-            blended.get("Amount"), field="Groups[].Metrics.BlendedCost.Amount"
+            metric.get("Amount"), field=f"Groups[].Metrics.{metric_name}.Amount"
         )
 
     return total_amount
 
 
-def _daily_totals(cost_data: Dict[str, Any]) -> Dict[str, Decimal]:
+def _daily_totals(cost_data: Dict[str, Any], metric_name: str) -> Dict[str, Decimal]:
     totals: Dict[str, Decimal] = {}
     for time_period in cost_data.get("ResultsByTime", []) or []:
         time_info = time_period.get("TimePeriod", {}) or {}
         date_str = time_info.get("Start")
         if not date_str:
             continue
-        totals[date_str] = _period_total(time_period)
+        totals[date_str] = _period_total(time_period, metric_name)
     return totals
 
 
-def _group_totals(cost_data: Dict[str, Any]) -> Dict[str, Decimal]:
+def _group_totals(cost_data: Dict[str, Any], metric_name: str) -> Dict[str, Decimal]:
     totals: Dict[str, Decimal] = {}
     for time_period in cost_data.get("ResultsByTime", []) or []:
         for group in time_period.get("Groups", []) or []:
             keys = group.get("Keys") or ["Unknown"]
             group_key = keys[0] if keys else "Unknown"
             metrics = group.get("Metrics") or {}
-            blended = metrics.get("BlendedCost") or {}
+            metric = metrics.get(metric_name) or {}
             amount = _to_decimal(
-                blended.get("Amount"), field="Groups[].Metrics.BlendedCost.Amount"
+                metric.get("Amount"), field=f"Groups[].Metrics.{metric_name}.Amount"
             )
             totals[group_key] = totals.get(group_key, Decimal("0")) + amount
     return totals
 
 
-def _daily_group_totals(cost_data: Dict[str, Any]) -> Dict[str, Dict[str, Decimal]]:
+def _daily_group_totals(
+    cost_data: Dict[str, Any], metric_name: str
+) -> Dict[str, Dict[str, Decimal]]:
     daily: Dict[str, Dict[str, Decimal]] = {}
     for time_period in cost_data.get("ResultsByTime", []) or []:
         date_str = (time_period.get("TimePeriod") or {}).get("Start")
@@ -106,8 +119,8 @@ def _daily_group_totals(cost_data: Dict[str, Any]) -> Dict[str, Dict[str, Decima
                 raise ValueError("Missing ResultsByTime[].Groups[].Keys[0]")
             name = str(keys[0])
             amount = _to_decimal(
-                ((group.get("Metrics") or {}).get("BlendedCost") or {}).get("Amount"),
-                field="Groups[].Metrics.BlendedCost.Amount",
+                ((group.get("Metrics") or {}).get(metric_name) or {}).get("Amount"),
+                field=f"Groups[].Metrics.{metric_name}.Amount",
             )
             groups[name] = groups.get(name, Decimal("0")) + amount
         daily[date_str] = groups
@@ -123,17 +136,20 @@ def build_cost_summary(
     window_end: date,
     schema_version: str = "1.0",
     top_n: Optional[int] = 10,
+    metric_name: str = "BlendedCost",
 ) -> Dict[str, Any]:
     """
     Build a compact dashboard summary from Cost Explorer responses.
 
     If previous_total_cost is zero, change_pct is returned as None.
     """
-    currency = _extract_currency(current_data)
+    if metric_name not in {"BlendedCost", "NetUnblendedCost"}:
+        raise ValueError(f"Unsupported AWS Cost Explorer metric: {metric_name}")
+    currency = _extract_currency(current_data, metric_name)
 
-    current_totals = _daily_totals(current_data)
-    daily_group_totals = _daily_group_totals(current_data)
-    previous_totals = _daily_totals(previous_data)
+    current_totals = _daily_totals(current_data, metric_name)
+    daily_group_totals = _daily_group_totals(current_data, metric_name)
+    previous_totals = _daily_totals(previous_data, metric_name)
 
     total_cost_decimal = sum(current_totals.values(), Decimal("0"))
     previous_total_decimal = sum(previous_totals.values(), Decimal("0"))
@@ -147,7 +163,7 @@ def build_cost_summary(
     else:
         change_pct = None
 
-    group_totals = _group_totals(current_data)
+    group_totals = _group_totals(current_data, metric_name)
     total_cost_value = _round_money(total_cost_decimal)
     previous_total_value = _round_money(previous_total_decimal)
 
@@ -191,7 +207,7 @@ def build_cost_summary(
             )
         cursor += timedelta(days=1)
 
-    return {
+    result = {
         "schema_version": schema_version,
         "currency": currency,
         "group_by": group_by,
@@ -203,3 +219,6 @@ def build_cost_summary(
         "daily_trend": daily_trend,
         "daily_groups": daily_groups,
     }
+    if metric_name != "BlendedCost":
+        result["aws_cost_metric"] = metric_name
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "finops-lite"
-version = "0.3.0"
+version = "0.4.0"
 description = "AWS cost visibility CLI and canonical CCAC producer"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_ccac.py
+++ b/tests/test_ccac.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -64,6 +67,95 @@ def test_ccac_demo_writes_payload_only_to_file(tmp_path):
     assert json.loads(target.read_text())["document_type"] == "tool_result"
 
 
+def test_explicit_1_0_preserves_legacy_total():
+    result = CliRunner().invoke(
+        cli, ["--no-cache", "ccac", "--demo", "--contract-version", "1.0.0"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["contract"] == "ccac/1.0.0"
+    assert any(metric["id"] == "metric.cloud.total" for metric in payload["metrics"])
+    assert not any("accounting_boundary" in metric for metric in payload["metrics"])
+
+
+def test_1_1_demo_emits_one_eligible_canonical_cloud_scope():
+    result = CliRunner().invoke(
+        cli, ["--no-cache", "ccac", "--demo", "--contract-version", "1.1.0"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    canonical = [
+        metric
+        for metric in payload["metrics"]
+        if metric.get("accounting_boundary", {}).get("relationship")
+        == "canonical_scope_spend"
+    ]
+    assert payload["contract"] == "ccac/1.1.0"
+    assert len(canonical) == 1
+    metric = canonical[0]
+    assert metric["id"] == "metric.tech-spend.scope.cloud"
+    assert metric["value"] == 2194.0
+    assert metric["currency"] == "USD"
+    assert metric["period"] == payload["period"]
+    assert metric["evidence_ids"] == ["evidence.finops-lite.cost-summary"]
+    assert not any(item["id"] == "metric.cloud.total" for item in payload["metrics"])
+    assert metric["accounting_boundary"] == {
+        "relationship": "canonical_scope_spend",
+        "scope": "cloud",
+        "canonical_owner": "finops-lite",
+        "source_channel": "cloud_provider_billing",
+        "cost_basis": "net_cost",
+        "currency_minor_unit": 0.01,
+        "inclusion_rules": [
+            "Cloud-provider-billed services, including provider-billed native AI, present in the authoritative AWS Cost Explorer summary."
+        ],
+        "exclusion_rules": [
+            "Direct AI-vendor billing and SaaS invoice or entitlement charges outside cloud-provider billing."
+        ],
+        "coverage": "complete",
+        "overlap": {
+            "disposition": "resolved",
+            "treatment": "Provider-billed native AI remains in Cloud; direct AI-vendor and SaaS billing channels are excluded.",
+        },
+        "cross_scope_treatments": {
+            "provider_billed_ai": "included",
+            "direct_ai_vendor": "excluded",
+        },
+        "component_treatments": {
+            "credits": "included",
+            "taxes": "included",
+            "adjustments": "included",
+            "shared_services": "included",
+        },
+        "allocation_of_metric_id": None,
+        "total_eligible": True,
+        "eligibility_reason": "The illustrative scenario declares AWS as its sole Cloud billing source; the unfiltered reconciled NetUnblendedCost summary covers the full scenario.",
+    }
+
+
+def test_1_1_cli_file_is_deterministic_and_passes_released_ccac(tmp_path):
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    runner = CliRunner()
+    args = ["--no-cache", "ccac", "--demo", "--contract-version", "1.1.0"]
+    for target in (first, second):
+        result = runner.invoke(cli, [*args, "--output", str(target)])
+        assert result.exit_code == 0, result.output
+    assert first.read_bytes() == second.read_bytes()
+
+    if os.environ.get("REQUIRE_CCAC_RELEASE_VALIDATION") != "1":
+        pytest.skip(
+            "released CCAC acceptance validator is enabled in CI/release verification"
+        )
+    validation = subprocess.run(
+        [sys.executable, "-m", "ccac.cli", "validate", str(first)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert validation.returncode == 0, validation.stdout + validation.stderr
+
+
 def test_ccac_real_mode_uses_complete_summary(monkeypatch):
     seen = {}
 
@@ -93,6 +185,68 @@ def test_ccac_real_mode_uses_complete_summary(monkeypatch):
     assert payload["mode"] == "real"
     assert payload["inputs"][0]["source_type"] == "aws_cost_explorer_api"
     assert payload["inputs"][0]["access"] == "external_read_only"
+
+
+def test_ccac_real_1_1_uses_net_unblended_cost_and_is_partial(monkeypatch):
+    seen = {}
+
+    def fake_run_summarize(*args, **kwargs):
+        seen.update(kwargs)
+        summary = illustrative_summary()
+        summary["aws_cost_metric"] = "NetUnblendedCost"
+        return summary
+
+    monkeypatch.setattr(cli_module, "run_summarize", fake_run_summarize)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--no-cache",
+            "ccac",
+            "--contract-version",
+            "1.1.0",
+            "--start",
+            "2026-07-01",
+            "--end",
+            "2026-07-21",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["cost_metric"] == "NetUnblendedCost"
+    payload = json.loads(result.output)
+    metric = next(item for item in payload["metrics"] if "accounting_boundary" in item)
+    assert metric["accounting_boundary"]["coverage"] == "partial"
+    assert metric["accounting_boundary"]["total_eligible"] is False
+    assert "Azure" in metric["accounting_boundary"]["eligibility_reason"]
+
+
+def test_ccac_real_1_1_refuses_blended_cost_fallback():
+    with pytest.raises(CCACBuildError, match="no fallback"):
+        build_ccac_result(
+            illustrative_summary(),
+            mode="real",
+            source_type="aws_cost_explorer_api",
+            source_version="2017-10-25",
+            contract_version="1.1.0",
+        )
+
+
+def test_ccac_1_1_rejects_unsupported_currency():
+    summary = illustrative_summary()
+    summary["currency"] = "JPY"
+    with pytest.raises(CCACBuildError, match="supports USD only"):
+        build_ccac_result(
+            summary,
+            mode="illustrative",
+            source_type="fixture",
+            source_version="1.0",
+            contract_version="1.1.0",
+        )
+
+
+def test_unsupported_contract_selection_fails_clearly():
+    result = CliRunner().invoke(cli, ["ccac", "--demo", "--contract-version", "2.0.0"])
+    assert result.exit_code == 2
+    assert "Invalid value for '--contract-version'" in result.output
 
 
 def test_ccac_rejects_non_reconciling_service_breakdown():

--- a/tests/test_ccac.py
+++ b/tests/test_ccac.py
@@ -5,12 +5,18 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
 
 import finops_lite.cli as cli_module
-from finops_lite.ccac import CCACBuildError, build_ccac_result, illustrative_summary
+from finops_lite.ccac import (
+    CCACBuildError,
+    build_ccac_result,
+    illustrative_summary,
+    illustrative_summary_1_1,
+)
 from finops_lite.cli import cli
 
 
@@ -107,7 +113,8 @@ def test_1_1_demo_emits_one_eligible_canonical_cloud_scope():
         "cost_basis": "net_cost",
         "currency_minor_unit": 0.01,
         "inclusion_rules": [
-            "Cloud-provider-billed services, including provider-billed native AI, present in the authoritative AWS Cost Explorer summary."
+            "Cloud-provider-billed services, including provider-billed native AI, present in the authoritative source summary.",
+            "The illustrative scenario follows Cloud & Capital's technology-spend boundary policy without asserting that an AWS API returned any charge type.",
         ],
         "exclusion_rules": [
             "Direct AI-vendor billing and SaaS invoice or entitlement charges outside cloud-provider billing."
@@ -129,8 +136,57 @@ def test_1_1_demo_emits_one_eligible_canonical_cloud_scope():
         },
         "allocation_of_metric_id": None,
         "total_eligible": True,
-        "eligibility_reason": "The illustrative scenario declares AWS as its sole Cloud billing source; the unfiltered reconciled NetUnblendedCost summary covers the full scenario.",
+        "eligibility_reason": "The deterministic public scenario declares net_cost and AWS as its sole illustrative Cloud source; no account or AWS API was queried.",
     }
+    previous = next(
+        item
+        for item in payload["metrics"]
+        if item["id"] == "metric.cloud.previous-total"
+    )
+    assert previous["period"] == {
+        "start": "2026-06-10",
+        "end": "2026-07-01",
+        "timezone": "UTC",
+    }
+    assert payload["period"] == {
+        "start": "2026-07-01",
+        "end": "2026-07-22",
+        "timezone": "UTC",
+    }
+    assert payload["extensions"]["finops_lite"]["illustrative_cost_basis"] == "net_cost"
+    assert payload["extensions"]["finops_lite"]["illustrative_cloud_sources"] == ["aws"]
+    assert payload["extensions"]["finops_lite"]["aws_api_queried"] is False
+    assert "aws_cost_metric" not in payload["extensions"]["finops_lite"]
+    assert "no account or AWS API was queried" in payload["evidence"][0]["description"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("illustrative_cost_basis", None, "illustrative_cost_basis=net_cost"),
+        ("illustrative_cost_basis", "billed_cost", "illustrative_cost_basis=net_cost"),
+        ("illustrative_cloud_sources", None, "sole illustrative Cloud source"),
+        (
+            "illustrative_cloud_sources",
+            ["aws", "azure"],
+            "sole illustrative Cloud source",
+        ),
+    ],
+)
+def test_1_1_demo_requires_explicit_illustrative_lineage(field, value, message):
+    summary = illustrative_summary_1_1()
+    if value is None:
+        summary.pop(field)
+    else:
+        summary[field] = value
+    with pytest.raises(CCACBuildError, match=message):
+        build_ccac_result(
+            summary,
+            mode="illustrative",
+            source_type="finops_lite_demo_summary",
+            source_version="1.0.0",
+            contract_version="1.1.0",
+        )
 
 
 def test_1_1_cli_file_is_deterministic_and_passes_released_ccac(tmp_path):
@@ -194,6 +250,7 @@ def test_ccac_real_1_1_uses_net_unblended_cost_and_is_partial(monkeypatch):
         seen.update(kwargs)
         summary = illustrative_summary()
         summary["aws_cost_metric"] = "NetUnblendedCost"
+        summary["comparison_window"] = {"start": "2026-06-10", "end": "2026-06-30"}
         return summary
 
     monkeypatch.setattr(cli_module, "run_summarize", fake_run_summarize)
@@ -228,6 +285,45 @@ def test_ccac_real_1_1_refuses_blended_cost_fallback():
             source_version="2017-10-25",
             contract_version="1.1.0",
         )
+
+
+def test_real_1_1_requests_only_net_unblended_without_filter(monkeypatch):
+    import finops_lite.core.cost_explorer as cost_explorer_module
+
+    requests = []
+
+    class FakeCostExplorerService:
+        def __init__(self, config):
+            pass
+
+        def get_cost_and_usage(self, *args, **kwargs):
+            requests.append(kwargs)
+            return {"ResultsByTime": []}
+
+    def fake_build_summary(*args, **kwargs):
+        summary = illustrative_summary()
+        summary["aws_cost_metric"] = "NetUnblendedCost"
+        return summary
+
+    monkeypatch.setattr(
+        cost_explorer_module, "CostExplorerService", FakeCostExplorerService
+    )
+    monkeypatch.setattr(cli_module, "_test_aws_connectivity", lambda *a, **k: None)
+    monkeypatch.setattr(cli_module, "build_cost_summary", fake_build_summary)
+
+    cli_module.run_summarize(
+        SimpleNamespace(aws=SimpleNamespace(profile=None, region=None)),
+        cli_module.date(2026, 7, 1),
+        cli_module.date(2026, 7, 21),
+        "SERVICE",
+        top_n=None,
+        cost_metric="NetUnblendedCost",
+    )
+    assert len(requests) == 2
+    assert all(request["metrics"] == ["NetUnblendedCost"] for request in requests)
+    assert all(
+        "Filter" not in request and "filter" not in request for request in requests
+    )
 
 
 def test_ccac_1_1_rejects_unsupported_currency():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ class TestCLIBasics:
     def test_version_option(self):
         result = CliRunner().invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert result.output.strip() == "finops-lite, version 0.3.0"
+        assert result.output.strip() == "finops-lite, version 0.4.0"
 
     def test_help_command(self):
         """Test help command."""

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -9,14 +9,14 @@ import pytest
 from finops_lite.summary import build_cost_summary
 
 
-def _make_day(start_date, total_amount, groups):
+def _make_day(start_date, total_amount, groups, metric_name="BlendedCost"):
     return {
         "TimePeriod": {
             "Start": start_date,
             "End": "unused",
         },
         "Total": {
-            "BlendedCost": {
+            metric_name: {
                 "Amount": str(total_amount),
                 "Unit": "USD",
             }
@@ -25,7 +25,7 @@ def _make_day(start_date, total_amount, groups):
             {
                 "Keys": [group_name],
                 "Metrics": {
-                    "BlendedCost": {
+                    metric_name: {
                         "Amount": str(amount),
                         "Unit": "USD",
                     }
@@ -179,3 +179,50 @@ def test_build_cost_summary_can_include_all_groups_for_reconciliation():
     )
     assert len(summary["top_groups"]) == 12
     assert sum(item["cost"] for item in summary["top_groups"]) == summary["total_cost"]
+
+
+def test_build_cost_summary_uses_only_selected_net_unblended_metric():
+    current = {
+        "ResultsByTime": [
+            _make_day("2026-01-01", 95, [("AmazonEC2", 95)], "NetUnblendedCost")
+        ]
+    }
+    summary = build_cost_summary(
+        current,
+        {"ResultsByTime": []},
+        group_by="SERVICE",
+        window_start=date(2026, 1, 1),
+        window_end=date(2026, 1, 1),
+        metric_name="NetUnblendedCost",
+    )
+    assert summary["total_cost"] == 95.0
+    assert summary["aws_cost_metric"] == "NetUnblendedCost"
+
+
+def test_build_cost_summary_never_falls_back_to_blended_cost():
+    current = {"ResultsByTime": [_make_day("2026-01-01", 100, [("AmazonEC2", 100)])]}
+    with pytest.raises(ValueError, match="Missing currency"):
+        build_cost_summary(
+            current,
+            {"ResultsByTime": []},
+            group_by="SERVICE",
+            window_start=date(2026, 1, 1),
+            window_end=date(2026, 1, 1),
+            metric_name="NetUnblendedCost",
+        )
+
+
+def test_net_unblended_summary_rejects_mixed_currency():
+    first = _make_day("2026-01-01", 50, [("AmazonEC2", 50)], "NetUnblendedCost")
+    second = _make_day("2026-01-02", 50, [("AmazonEC2", 50)], "NetUnblendedCost")
+    second["Total"]["NetUnblendedCost"]["Unit"] = "EUR"
+    second["Groups"][0]["Metrics"]["NetUnblendedCost"]["Unit"] = "EUR"
+    with pytest.raises(ValueError, match="Mixed currency"):
+        build_cost_summary(
+            {"ResultsByTime": [first, second]},
+            {"ResultsByTime": []},
+            group_by="SERVICE",
+            window_start=date(2026, 1, 1),
+            window_end=date(2026, 1, 2),
+            metric_name="NetUnblendedCost",
+        )

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -189,7 +189,11 @@ def test_build_cost_summary_uses_only_selected_net_unblended_metric():
     }
     summary = build_cost_summary(
         current,
-        {"ResultsByTime": []},
+        {
+            "ResultsByTime": [
+                _make_day("2025-12-31", 90, [("AmazonEC2", 90)], "NetUnblendedCost")
+            ]
+        },
         group_by="SERVICE",
         window_start=date(2026, 1, 1),
         window_end=date(2026, 1, 1),
@@ -197,6 +201,10 @@ def test_build_cost_summary_uses_only_selected_net_unblended_metric():
     )
     assert summary["total_cost"] == 95.0
     assert summary["aws_cost_metric"] == "NetUnblendedCost"
+    assert summary["comparison_window"] == {
+        "start": "2025-12-31",
+        "end": "2025-12-31",
+    }
 
 
 def test_build_cost_summary_never_falls_back_to_blended_cost():
@@ -220,9 +228,78 @@ def test_net_unblended_summary_rejects_mixed_currency():
     with pytest.raises(ValueError, match="Mixed currency"):
         build_cost_summary(
             {"ResultsByTime": [first, second]},
-            {"ResultsByTime": []},
+            {
+                "ResultsByTime": [
+                    _make_day(
+                        "2025-12-30", 40, [("AmazonEC2", 40)], "NetUnblendedCost"
+                    ),
+                    _make_day(
+                        "2025-12-31", 40, [("AmazonEC2", 40)], "NetUnblendedCost"
+                    ),
+                ]
+            },
             group_by="SERVICE",
             window_start=date(2026, 1, 1),
             window_end=date(2026, 1, 2),
             metric_name="NetUnblendedCost",
         )
+
+
+def _net_summary(current, previous, start=date(2026, 1, 1), end=date(2026, 1, 1)):
+    return build_cost_summary(
+        {"ResultsByTime": current},
+        {"ResultsByTime": previous},
+        group_by="SERVICE",
+        window_start=start,
+        window_end=end,
+        metric_name="NetUnblendedCost",
+    )
+
+
+def test_net_unblended_rejects_missing_previous_date():
+    current = [_make_day("2026-01-01", 50, [("EC2", 50)], "NetUnblendedCost")]
+    with pytest.raises(ValueError, match="Incomplete previous-period"):
+        _net_summary(current, [])
+
+
+def test_net_unblended_rejects_duplicate_previous_date():
+    current = [_make_day("2026-01-01", 50, [("EC2", 50)], "NetUnblendedCost")]
+    previous = [
+        _make_day("2025-12-31", 40, [("EC2", 40)], "NetUnblendedCost"),
+        _make_day("2025-12-31", 40, [("EC2", 40)], "NetUnblendedCost"),
+    ]
+    with pytest.raises(ValueError, match="Duplicate date"):
+        _net_summary(current, previous)
+
+
+def test_net_unblended_rejects_unexpected_previous_date():
+    current = [_make_day("2026-01-01", 50, [("EC2", 50)], "NetUnblendedCost")]
+    previous = [_make_day("2025-12-30", 40, [("EC2", 40)], "NetUnblendedCost")]
+    with pytest.raises(ValueError, match="unexpected"):
+        _net_summary(current, previous)
+
+
+def test_net_unblended_rejects_missing_previous_currency():
+    current = [_make_day("2026-01-01", 50, [("EC2", 50)], "NetUnblendedCost")]
+    previous = [_make_day("2025-12-31", 40, [("EC2", 40)], "NetUnblendedCost")]
+    previous[0]["Total"]["NetUnblendedCost"].pop("Unit")
+    previous[0]["Groups"][0]["Metrics"]["NetUnblendedCost"].pop("Unit")
+    with pytest.raises(ValueError, match="Missing currency"):
+        _net_summary(current, previous)
+
+
+def test_net_unblended_rejects_mixed_previous_currency():
+    current = [_make_day("2026-01-01", 50, [("EC2", 50)], "NetUnblendedCost")]
+    previous = [_make_day("2025-12-31", 40, [("EC2", 40)], "NetUnblendedCost")]
+    previous[0]["Groups"][0]["Metrics"]["NetUnblendedCost"]["Unit"] = "EUR"
+    with pytest.raises(ValueError, match="Mixed currency"):
+        _net_summary(current, previous)
+
+
+def test_net_unblended_rejects_current_previous_currency_mismatch():
+    current = [_make_day("2026-01-01", 50, [("EC2", 50)], "NetUnblendedCost")]
+    previous = [_make_day("2025-12-31", 40, [("EC2", 40)], "NetUnblendedCost")]
+    previous[0]["Total"]["NetUnblendedCost"]["Unit"] = "EUR"
+    previous[0]["Groups"][0]["Metrics"]["NetUnblendedCost"]["Unit"] = "EUR"
+    with pytest.raises(ValueError, match="currency mismatch"):
+        _net_summary(current, previous)

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "finops-lite"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- prepare FinOps Lite 0.4.0 while preserving CCAC 1.0.0 as the default compatibility path
- add explicit CCAC 1.1.0 output with exactly one FinOps Lite-owned canonical Cloud scope metric
- query AWS Cost Explorer `NetUnblendedCost` for real 1.1 output without falling back to `BlendedCost`
- keep real AWS-only coverage partial and ineligible for an all-in technology-spend total
- validate CLI-generated 1.0 and 1.1 artifacts with the exact released CCAC 0.2.0 wheel and verified SHA-256

## Accounting boundary and lineage

The explicit 1.1 illustrative scenario declares `illustrative_cost_basis=net_cost` and AWS as its sole illustrative Cloud source. It is a deterministic public scenario: no account or AWS API is queried. It retains the USD 2,194.00 value, all 21 current-period dates, and the approved run identity.

The real 1.1 path executes current and immediately preceding equal-length AWS Cost Explorer `NetUnblendedCost` requests without a charge-type filter. Under Cloud & Capital's technology-spend boundary policy, credits, taxes, adjustments, and shared services are included when AWS returns them in that unfiltered result. Current and prior date inventories and currencies fail closed on missing, duplicate, unexpected, mixed, or mismatched input.

The illustrative current CCAC period is `2026-07-01` through `2026-07-22` exclusive. Its previous metric is accurately dated `2026-06-10` through `2026-07-01` exclusive. Provider-billed native AI is included in Cloud; direct AI-vendor billing is excluded. Real AWS output does not claim Azure, Google Cloud, or complete enterprise Cloud coverage.

Cloud Cost Guard and all other producers and consumers remain unconnected and unchanged.

## Verification

- 93 tests passed with the released CCAC acceptance validator; GitHub Actions covers Python 3.10, 3.11, and 3.12
- focused default/explicit 1.0 compatibility tests passed; the approved financial values, metric IDs, and contract remain unchanged
- generated default 1.0 and explicit 1.1 artifacts pass CCAC 0.2.0 validation; the wheel SHA-256 is `bc46f363b1a03c94cf0da75759bccd0271de2c53b1f77a1a7255f9c8e7f768f1`
- deterministic 1.1 CLI output confirmed byte-for-byte
- wheel and sdist each built twice byte-identically: wheel `821468814031e468588023a9b1af4402d288c1cbb01505cfa7ff9afb01b2ca2b`; sdist `657e29a89116115d5cef8d1403849e1c1b0f2506844e2acb3ea7e0e18de9c776`
- clean wheel installation and CLI version/default-1.0/explicit-1.1 smoke tests passed
- JSON, TOML, lockfile, and workflow YAML parsing passed
- Black, isort, actionable flake8, production dependency audit, portability, secret-pattern, environment-file, declared-import, and `git diff --check` checks passed
- the v0.3.0 tag remains unchanged; the tracked illustrative report hash remains `5b38a371cea9d684732bb6135f5328bd3de7b171327fd19582fcaa42ab914f54`
